### PR TITLE
Configure SendGrid 

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,8 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  raise 'SENDGRID_API_KEY not present' unless ENV['SENDGRID_API_KEY']
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
@@ -63,6 +65,16 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "womens_directory_production"
 
   config.action_mailer.perform_caching = false
+
+  ActionMailer::Base.smtp_settings = {
+    user_name: 'apikey',
+    password: ENV['SENDGRID_API_KEY'],
+    domain: 'womensdirectory.org',
+    address: 'smtp.sendgrid.net',
+    port: 587,
+    authentication: :plain,
+    enable_starttls_auto: true,
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
This PR configures the app to send email via SendGrid. We need this so that we can log in via Passwordless.