### PR TITLE
Add description to categories

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,10 +2,11 @@
 #
 # Table name: categories
 #
-#  id         :bigint           not null, primary key
-#  name       :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id          :bigint           not null, primary key
+#  description :text
+#  name        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
 #
 class Category < ApplicationRecord
   has_and_belongs_to_many :locations

--- a/db/migrate/20210516015652_add_description_to_categories.rb
+++ b/db/migrate/20210516015652_add_description_to_categories.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToCategories < ActiveRecord::Migration[6.1]
+  def change
+    add_column :categories, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_13_011013) do
+ActiveRecord::Schema.define(version: 2021_05_16_015652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 2021_05_13_011013) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "description"
   end
 
   create_table "categories_locations", id: false, force: :cascade do |t|


### PR DESCRIPTION
Closes #23.

This adds a `description` field to Categories, so e.g. we can trim the name for "Legal Aid" and describe it in-depth on its Category page (after the user clicks through).
