### PR TITLE
Strip spaces from string fields

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,25 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def self.strips_spaces_from_string_fields
+    before_save :strip_strings
+  end
+
+  private
+
+  def strip_strings
+    self.class.columns.
+      # for every `string` or `text`-type column,
+      filter { |c| %i[string text].include? c.type }.
+      each do |col|
+        # get the existing value
+        raw = send col.name.to_sym
+        return unless raw
+
+        # strip spaces and set the new value
+        setter = "#{col.name}=".to_sym
+        clean = raw.strip
+        self.send setter, clean
+      end
+  end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -11,6 +11,7 @@
 class Category < ApplicationRecord
   has_and_belongs_to_many :locations
   validates_presence_of :name
+  strips_spaces_from_string_fields
 
   def to_s
     "#<Category #{id}: #{name}>"

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -11,4 +11,5 @@
 #  updated_at :datetime         not null
 #
 class Feedback < ApplicationRecord
+  strips_spaces_from_string_fields
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -30,6 +30,7 @@ class Location < ApplicationRecord
   belongs_to :org
   has_and_belongs_to_many :categories
   validates_presence_of :city, :desc, :name, :state, :zip
+  strips_spaces_from_string_fields
 
   def website_without_protocol
     match = /https?:\/\/(.+)/.match website

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -12,6 +12,7 @@
 class Org < ApplicationRecord
   has_many :locations, dependent: :destroy
   validates_presence_of :desc, :name, :website
+  strips_spaces_from_string_fields
 
   def to_s
     "#<Org #{id}: #{name}>"

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationRecord do
+  describe 'strips_spaces_from_string_fields' do
+    it 'strips spaces from string and text fields on an object' do
+      org = Org.create! name: '  Widgets Inc    ', desc: '  We sell high-quality widgets ', website: '  example.com '
+      expect(org).to have_attributes name: 'Widgets Inc', desc: 'We sell high-quality widgets', website: 'example.com'
+    end
+  end
+end


### PR DESCRIPTION
Closes #19.

Strips leading and trailing spaces on columns of type `string` and `text` for models annotated with `strips_spaces_from_string_fields`.
