### PR TITLE
Hide map for locations without address1

### DIFF
--- a/app/views/location/show.html.erb
+++ b/app/views/location/show.html.erb
@@ -6,6 +6,8 @@
   <div class="column">
     <%= markdown @location.desc %>
     <div class="mb-3"></div>
+
+    <% if @location.address1 %>
     <div class="map-embed mb-2" data-latitude="<%= @location.latitude %>" data-longitude="<%= @location.longitude %>"></div>
     <div class="mb-3">
       <p><%= @location.neighborhood %></p>
@@ -14,6 +16,10 @@
       <p><a target="_blank" href="http://maps.apple.com/?q=<%= @location.full_address_with_name %>">Open in Apple Maps</a></p>
       <p><a target="_blank" href="http://maps.google.com/?q=<%= @location.full_address_with_name %>">Open in Google Maps</a></p>
     </div>
+    <% else %>
+    <p class="mb-2"><%= @location.city %>, <%= @location.state %></p>
+    <% end %>
+
     <p>
       <span class="has-text-weight-bold">
         Organization: <%= link_to @location.org.name, show_org_path %>


### PR DESCRIPTION
Closes #41.

Hides the map view for locations that lack an `address1` value. For example, domestic violence programs often only have a phone number and no address available.

With address:
![Screen Shot 2021-05-29 at 1 41 59 PM](https://user-images.githubusercontent.com/1829094/120083099-b384b680-c083-11eb-933f-d4a3cceb5f25.png)

Without address:
![Screen Shot 2021-05-29 at 1 41 49 PM](https://user-images.githubusercontent.com/1829094/120083100-b4b5e380-c083-11eb-8c63-73768012d296.png)
