### PR TITLE
Fix route precedence for locations and categories

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,8 +13,8 @@ Rails.application.routes.draw do
   root to: 'home#home'
   get 'location/:id', to: 'location#show', as: 'show_location'
 
-  get ':id', to: 'category#show', as: 'show_category', constraints: { id: lead_num }
   get ':cat_id/:id', to: 'location#show', as: 'show_category_location', constraints: { cat_id: lead_num, id: lead_num }
+  get ':id', to: 'category#show', as: 'show_category', constraints: { id: lead_num }
 
   get 'org/:id', to: 'org#show', as: 'show_org'
   post 'feedback', to: 'feedback#save', as: 'save_feedback'


### PR DESCRIPTION
@AARodgers reported that she could not click into a Location. Going to that link showed its Category.

This resolves a route precedence issue and allows users to navigate into Locations now.