### PR TITLE
Visible categories

### DIFF
--- a/app/helpers/shared/categories_helper.rb
+++ b/app/helpers/shared/categories_helper.rb
@@ -2,6 +2,6 @@ module Shared::CategoriesHelper
   COLUMN_COUNT = 2
 
   def category_columns
-    Category.all.order(:name).in_groups(COLUMN_COUNT, false)
+    Category.where(visible: true).order(:name).in_groups(COLUMN_COUNT, false)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -5,6 +5,7 @@
 #  id          :bigint           not null, primary key
 #  description :text
 #  name        :string           not null
+#  visible     :boolean          default(TRUE), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #

--- a/db/migrate/20210610181656_add_hidden_to_categories.rb
+++ b/db/migrate/20210610181656_add_hidden_to_categories.rb
@@ -1,0 +1,5 @@
+class AddHiddenToCategories < ActiveRecord::Migration[6.1]
+  def change
+    add_column :categories, :visible, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_29_200300) do
+ActiveRecord::Schema.define(version: 2021_06_10_181656) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2021_05_29_200300) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "description"
+    t.boolean "visible", default: true, null: false
   end
 
   create_table "categories_locations", id: false, force: :cascade do |t|


### PR DESCRIPTION
Allows us to mark a category as `visible: false` in the Admin panel so that we can hide categories from the front page, without deleting their data.