### PR TITLE
Only show pages in navbar if they are published in cms

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,7 +46,7 @@ class ApplicationController < ActionController::Base
 
   # List all CMS pages that are "top level" - immediate children of the root page, excluding the root page
   def top_level_pages
-    Comfy::Cms::Page.where(parent_id: root_page).order :position
+    Comfy::Cms::Page.published.where(parent_id: root_page).order :position
   end
 
   def user_coords


### PR DESCRIPTION
This lets us uncheck the **Published** checkbox in the CMS to hide a page from the navbar without deleting it entirely.