### PR TITLE
Add Discord webhook url to env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If you land code that includes database migrations, you must run them manually i
 | Key                   | Description                                                                                          |
 | --------------------- | ---------------------------------------------------------------------------------------------------- |
 | `APP_DOMAIN`          | The domain where the application lives (currently `womens-directory-kgjo4.ondigitalocean.app`)       |
-| `DISCORD_WEBHOOK_URL` | The URL for a Discord channel's webhook, used forwarding website feedback to WD staff                |
+| `DISCORD_WEBHOOK_URL` | The URL for a Discord channel's webhook, used for forwarding website feedback to WD staff            |
 | `EMAIL_DOMAIN`        | The send-from domain used for emails, authorized for use in SendGrid (usually `womensdirectory.org`) |
 | `GOOGLE_MAPS_API_KEY` | The API key for the Google Cloud project with access to geocoding                                    |
 | `INSECURE`            | If set, uses HTTP for URLs; if unset (default), uses HTTPS                                           |


### PR DESCRIPTION
This was missing from the README.