### PR TITLE
User invites

### DIFF
--- a/app/controllers/admin/user_invites_controller.rb
+++ b/app/controllers/admin/user_invites_controller.rb
@@ -5,6 +5,10 @@ class Admin::UserInvitesController < ApplicationController
   end
 
   def create
+    email = params[:email]
+    User.create! email: email, roles: [:data_contributor]
+    flash[:notice] = "Invitation sent to #{email}."
+    redirect_to request.path
   end
 
   def require_authorized_user!

--- a/app/controllers/admin/user_invites_controller.rb
+++ b/app/controllers/admin/user_invites_controller.rb
@@ -6,7 +6,8 @@ class Admin::UserInvitesController < ApplicationController
 
   def create
     email = params[:email]
-    User.create! email: email, roles: [:data_contributor]
+    user = User.create! email: email, roles: [:data_contributor]
+    UserMailer.welcome(user).deliver_now
     flash[:notice] = "Invitation sent to #{email}."
     redirect_to request.path
   end

--- a/app/controllers/admin/user_invites_controller.rb
+++ b/app/controllers/admin/user_invites_controller.rb
@@ -1,0 +1,7 @@
+class Admin::UserInvitesController < ApplicationController
+  def new
+  end
+
+  def create
+  end
+end

--- a/app/controllers/admin/user_invites_controller.rb
+++ b/app/controllers/admin/user_invites_controller.rb
@@ -1,7 +1,14 @@
 class Admin::UserInvitesController < ApplicationController
+  before_action :require_authorized_user!
+
   def new
   end
 
   def create
+  end
+
+  def require_authorized_user!
+    require_user!
+    authorize! :invite, User
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,6 @@
+class UserMailer < ApplicationMailer
+  def welcome(user)
+    @greeting = "Hi"
+    mail to: user.email
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,5 @@
 class UserMailer < ApplicationMailer
   def welcome(user)
-    @greeting = "Hi"
-    mail to: user.email
+    mail from: 'signin@womensdirectory.org', to: user.email
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -33,10 +33,9 @@ class Ability
       can :manage, :all
     end
 
-    # User editors can invite and edit users.
+    # User inviters can invite new contributors.
     if user.user_inviter?
-      # TODO: Users should not be able to edit other user editors
-      can :manage, User
+      can :invite, User
     end
 
     # CMS editors can manage all pages and content within the CMS.

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -34,7 +34,7 @@ class Ability
     end
 
     # User editors can invite and edit users.
-    if user.user_editor?
+    if user.user_inviter?
       # TODO: Users should not be able to edit other user editors
       can :manage, User
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
   # Do not reorder this list! Add new roles at the BOTTOM of the list only!
   roles %i[
     superadmin
-    user_editor
+    user_inviter
     cms_editor
     data_editor
     data_contributor

--- a/app/views/admin/user_invites/new.html.erb
+++ b/app/views/admin/user_invites/new.html.erb
@@ -1,2 +1,19 @@
-<h1>Admin::UserInvites#new</h1>
-<p>Find me in app/views/admin/user_invites/new.html.erb</p>
+<h1 class="is-size-3 mb-1">Invite New Volunteer</h1>
+<p class="mb-1">
+  Enter the new volunteer's email address to create a new Women's Directory account for them.
+</p>
+<p class="mb-3">
+  The volunteer you invite will have the <strong>collaborator</strong> role.
+  They will be able to create new resources (e.g. Location, Org) but not modify or delete existing ones.
+  They will not be able to create new categories.
+</p>
+<div>
+  <%= form_with url: admin_user_permissions_path do |f| %>
+    <div class="mb-2">
+      <button class="button is-success has-text-weight-bold" type="submit">📨 Send Invite</button>
+    </div>
+    <div>
+      <a class="button" href="/">&laquo; Cancel</a>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/user_invites/new.html.erb
+++ b/app/views/admin/user_invites/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::UserInvites#new</h1>
+<p>Find me in app/views/admin/user_invites/new.html.erb</p>

--- a/app/views/admin/user_invites/new.html.erb
+++ b/app/views/admin/user_invites/new.html.erb
@@ -1,14 +1,16 @@
-<h1 class="is-size-3 mb-1">Invite New Volunteer</h1>
+<h1 class="is-size-3 mb-1">Invite New Contributor</h1>
 <p class="mb-1">
-  Enter the new volunteer's email address to create a new Women's Directory account for them.
+  Enter the contributor's email address to create a Women's Directory account for them.
 </p>
 <p class="mb-3">
-  The volunteer you invite will have the <strong>collaborator</strong> role.
-  They will be able to create new resources (e.g. Location, Org) but not modify or delete existing ones.
-  They will not be able to create new categories.
+  Contributors can add new locations and organizations,
+  but new locations will not be visible until an editor approves them.
 </p>
 <div>
-  <%= form_with url: admin_user_permissions_path do |f| %>
+  <%= form_with url: admin_user_invites_path do |f| %>
+    <div class="mb-2">
+      <%= f.text_field :email, class: 'input', type: :email, placeholder: 'name@example.com' %>
+    </div>
     <div class="mb-2">
       <button class="button is-success has-text-weight-bold" type="submit">📨 Send Invite</button>
     </div>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -32,6 +32,9 @@
                 <a class="navbar-item" href="/cms" target="_blank">CMS</a>
               <% end %>
               <a class="navbar-item" href="/admin/changes">Recent Changes</a>
+              <% if current_user.can? :invite, User %>
+                <a class="navbar-item" href="<%= admin_user_invites_path %>" target="_blank">Invite New Volunteer</a>
+              <% end %>
               <% if current_user.can? :manage, :user_permissions %>
                 <a class="navbar-item" href="<%= admin_user_permissions_path %>" target="_blank">User Permissions</a>
               <% end %>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -33,7 +33,7 @@
               <% end %>
               <a class="navbar-item" href="/admin/changes">Recent Changes</a>
               <% if current_user.can? :invite, User %>
-                <a class="navbar-item" href="<%= admin_user_invites_path %>" target="_blank">Invite New Volunteer</a>
+                <a class="navbar-item" href="<%= admin_user_invites_path %>" target="_blank">Invite New Contributor</a>
               <% end %>
               <% if current_user.can? :manage, :user_permissions %>
                 <a class="navbar-item" href="<%= admin_user_permissions_path %>" target="_blank">User Permissions</a>

--- a/app/views/user_mailer/welcome.text.erb
+++ b/app/views/user_mailer/welcome.text.erb
@@ -1,0 +1,3 @@
+User#welcome
+
+<%= @greeting %>, find me in app/views/user_mailer/welcome.text.erb

--- a/app/views/user_mailer/welcome.text.erb
+++ b/app/views/user_mailer/welcome.text.erb
@@ -1,3 +1,9 @@
-User#welcome
+Hello! Thank you for volunteering to help with Women's Directory. We're happy you are here.
 
-<%= @greeting %>, find me in app/views/user_mailer/welcome.text.erb
+Use this link to sign into Women's Directory:
+https://womensdirectory.org/users/sign_in
+
+Please save this email or bookmark this link so you can find it in the future.
+
+Welcome aboard!
+– The Women's Directory Team

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
     get 'birdseye/categories'
     get 'birdseye/categories/:id', to: 'birdseye#category', as: 'birdseye_category'
     get 'changes', to: 'changes#changes', as: 'changes'
+    get 'user_invites', to: 'user_invites#new'
+    post 'user_invites', to: 'user_invites#create'
     get 'user_permissions', to: 'user_permissions#index'
     post 'user_permissions', to: 'user_permissions#update'
   end

--- a/spec/logic/user_permissions_spec.rb
+++ b/spec/logic/user_permissions_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe UserPermissions do
     subject { described_class.set_all! current_user, params }
 
     context 'with a user who is not a superadmin' do
-      let(:current_user) { User.new roles: [:user_editor] }
+      let(:current_user) { User.new roles: [:user_inviter] }
       let(:params) { { whatever: :doesnt_matter } }
       it "does not allow the user to change any user's permissions" do
         expect { subject }.to raise_error "Not authorized"
@@ -19,25 +19,25 @@ RSpec.describe UserPermissions do
       let(:params) do
         {
           '1-superadmin' => '1',
-          '1-user_editor' => '0',
+          '1-user_inviter' => '0',
           '1-cms_editor' => '0',
           '1-data_editor' => '0',
           '1-data_contributor' => '0',
 
           '2-superadmin' => '0',
-          '2-user_editor' => '1',
+          '2-user_inviter' => '1',
           '2-cms_editor' => '1',
           '2-data_editor' => '1',
           '2-data_contributor' => '0',
 
           '3-superadmin' => '0',
-          '3-user_editor' => '0',
+          '3-user_inviter' => '0',
           '3-cms_editor' => '0',
           '3-data_editor' => '0',
           '3-data_contributor' => '1',
 
           '4-superadmin' => '0',
-          '4-user_editor' => '0',
+          '4-user_inviter' => '0',
           '4-cms_editor' => '0',
           '4-data_editor' => '0',
           '4-data_contributor' => '0',
@@ -48,13 +48,13 @@ RSpec.describe UserPermissions do
         expect { subject }
           .to not_change { current_user.reload.roles }
           .and change { user_1.reload.roles }.from([]).to(%i[superadmin])
-          .and change { user_2.reload.roles }.from([]).to(%i[user_editor cms_editor data_editor])
+          .and change { user_2.reload.roles }.from([]).to(%i[user_inviter cms_editor data_editor])
           .and change { user_3.reload.roles }.from(%i[data_editor]).to(%i[data_contributor])
           .and not_change { user_4.reload.roles }
       end
 
       context 'with invalid value' do
-        let(:params) { { '2-user_editor' => 'true' } }
+        let(:params) { { '2-user_inviter' => 'true' } }
         it 'raises the expected error' do
           expect { subject }.to raise_error "Invalid value true"
         end


### PR DESCRIPTION
This renames user_editor to user_inviter. User inviters can now invite new users through the **Invite New Contributor** interface under the **Admin** dropdown:

![image](https://user-images.githubusercontent.com/1829094/161881972-53a9d430-157b-4b34-82dc-fcb309ea9849.png)

The website sends new users an email with the sign-in link.