### PR TITLE
Install Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ gem 'rest-client', '~> 2.1'
 gem 'rexml', '~> 3.2'
 gem "role_model", '~> 0.8'
 gem 'rspec-rails', '~> 5.0'
+gem 'sentry-ruby', '~> 5.6'
+gem 'sentry-rails', '~> 5.6'
 gem 'shakapacker', '~> 6.2'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,6 +364,11 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
+    sentry-rails (5.6.0)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.6.0)
+    sentry-ruby (5.6.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     sexp_processor (4.15.2)
     shakapacker (6.2.1)
       activesupport (>= 5.2)
@@ -450,6 +455,8 @@ DEPENDENCIES
   rspec-rails (~> 5.0)
   sass-rails (>= 6)
   selenium-webdriver
+  sentry-rails (~> 5.6)
+  sentry-ruby (~> 5.6)
   shakapacker (~> 6.2)
   spring
   sprockets (< 4)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,5 @@
+Sentry.init do |config|
+  config.dsn = 'https://d8b25a2af764474fb35a7cde27e2c53c@o4504147777224704.ingest.sentry.io/4504147815366656'
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+  config.traces_sample_rate = 1.0
+end


### PR DESCRIPTION
This reports our runtime crashes to Sentry where we can aggregate and fix them.